### PR TITLE
Fix local development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ access remote files in the s3 bucket.
 Clone the project
 
 ```bash
-  git clone git@bitbucket.org:andrewfreddin/learnarabic.git
+  git clone git@github.com:PalWeb-Online/PalWeb.git
 ```
 
 Go to the project directory

--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ Clone the project
   git clone git@github.com:PalWeb-Online/PalWeb.git
 ```
 
-Go to the project directory
-
-```bash
-  cd learnarabic
-```
-
 Compose Up docker container
 
 ```bash


### PR DESCRIPTION
This should close #3. The previous bitbucket link seems to be dead. Updated to the current GH repository.

Edit: Also removed the subsequent step which seems to direct users to a no-longer-existing directory before installing the deps, presumably that directory is now the root