### PR TITLE
fix: clock drift + account for daylight savings in UTC time offset

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -41,9 +41,9 @@ class HandleInertiaRequests extends Middleware
                     ? new \App\Http\Resources\AuthUserResource($request->user()->load(['roles']))
                     : null,
             ],
-            'time' => now()
+            'utcOffsetMinutes' => now()
                 ->setTimezone('Asia/Jerusalem')
-                ->format('Y-m-d H:i:s'),
+                ->utcOffset(),
             'flash' => [
                 'notification' => fn () => $request->session()->get('notification'),
                 'denied' => fn () => $request->session()->get('denied')

--- a/resources/js/Shared/NavSticky.vue
+++ b/resources/js/Shared/NavSticky.vue
@@ -84,7 +84,10 @@ onMounted(() => {
             <Link :href="route('homepage')">PalWeb 2.0 (Watermelon)</Link>
         </div>
         <div class="nav-sticky-buttons">
-            <button class="material-symbols-rounded" @click="showThemePicker = true">
+            <button
+                class="material-symbols-rounded"
+                @click="showThemePicker = true"
+            >
                 palette
             </button>
             <button
@@ -93,33 +96,36 @@ onMounted(() => {
             >
                 search
             </button>
-            <button class="material-symbols-rounded" @click.stop="NavigationStore.toggleSidebar">
+            <button
+                class="material-symbols-rounded"
+                @click.stop="NavigationStore.toggleSidebar"
+            >
                 menu
             </button>
         </div>
     </div>
 
-<!--    <x-dropdown>-->
-<!--        <x-slot name="trigger">-->
-<!--            <a class="material-symbols-rounded" @click="open = ! open">language</a>-->
-<!--        </x-slot>-->
-<!--        <x-slot name="content">-->
-<!--            <form id="frm-en" method="post" action="{{ route("language.store", "en") }}">-->
-<!--            @csrf-->
-<!--            <button onclick="this.closest('form').submit();return false;">EN</button>-->
-<!--            </form>-->
+    <!--    <x-dropdown>-->
+    <!--        <x-slot name="trigger">-->
+    <!--            <a class="material-symbols-rounded" @click="open = ! open">language</a>-->
+    <!--        </x-slot>-->
+    <!--        <x-slot name="content">-->
+    <!--            <form id="frm-en" method="post" action="{{ route("language.store", "en") }}">-->
+    <!--            @csrf-->
+    <!--            <button onclick="this.closest('form').submit();return false;">EN</button>-->
+    <!--            </form>-->
 
-<!--            <form id="frm-es" method="post" action="{{ route("language.store", "es") }}">-->
-<!--            @csrf-->
-<!--            <button onclick="this.closest('form').submit();return false;">ES</button>-->
-<!--            </form>-->
+    <!--            <form id="frm-es" method="post" action="{{ route("language.store", "es") }}">-->
+    <!--            @csrf-->
+    <!--            <button onclick="this.closest('form').submit();return false;">ES</button>-->
+    <!--            </form>-->
 
-<!--            <form id="frm-ar" method="post" action="{{ route("language.store", "ar") }}">-->
-<!--            @csrf-->
-<!--            <button onclick="this.closest('form').submit();return false;">AR</button>-->
-<!--            </form>-->
-<!--        </x-slot>-->
-<!--    </x-dropdown>-->
+    <!--            <form id="frm-ar" method="post" action="{{ route("language.store", "ar") }}">-->
+    <!--            @csrf-->
+    <!--            <button onclick="this.closest('form').submit();return false;">AR</button>-->
+    <!--            </form>-->
+    <!--        </x-slot>-->
+    <!--    </x-dropdown>-->
 
     <ModalWrapper v-model="showThemePicker">
         <ThemePicker />

--- a/resources/js/Shared/NavSticky.vue
+++ b/resources/js/Shared/NavSticky.vue
@@ -1,10 +1,10 @@
 <script setup>
-import {route} from "ziggy-js";
-import {useNavigationStore} from "../stores/NavigationStore.js";
-import {useSearchStore} from "../stores/SearchStore.js";
-import {onBeforeUnmount, onMounted, ref} from "vue";
+import { route } from "ziggy-js";
+import { useNavigationStore } from "../stores/NavigationStore.js";
+import { useSearchStore } from "../stores/SearchStore.js";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 import ThemePicker from "../components/Modals/ThemePicker.vue";
-import {usePage} from "@inertiajs/vue3";
+import { usePage } from "@inertiajs/vue3";
 import ModalWrapper from "../components/Modals/ModalWrapper.vue";
 
 const NavigationStore = useNavigationStore();
@@ -12,55 +12,85 @@ const SearchStore = useSearchStore();
 
 const showThemePicker = ref(false);
 
-const page = usePage();
-const time = ref(new Date(page.props.time));
+const {
+    props: { utcOffsetMinutes },
+} = usePage();
+
+const utcOffsetHours = utcOffsetMinutes / 60;
+
+const time = ref(Date.now());
 
 const updateTime = () => {
-    time.value = new Date(time.value.getTime() + 1000);
+    const newTime = Date.now();
+
+    if (time.value !== newTime) {
+        time.value = newTime;
+
+        requestAnimationFrame(updateTime);
+    }
 };
 
 onMounted(() => {
-    setInterval(updateTime, 1000);
+    updateTime();
 
     const globalListener = (event) => {
-        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
 
-        if ((isMac && event.metaKey && event.key === 'k') || (!isMac && event.ctrlKey && event.key === 'k')) {
+        if (
+            (isMac && event.metaKey && event.key === "k") ||
+            (!isMac && event.ctrlKey && event.key === "k")
+        ) {
             event.preventDefault();
 
-            if (SearchStore.data.isOpen && SearchStore.data.action === 'search') {
+            if (
+                SearchStore.data.isOpen &&
+                SearchStore.data.action === "search"
+            ) {
                 SearchStore.data.isOpen = false;
-
             } else if (!SearchStore.data.isOpen) {
-                SearchStore.openSearchGenie('search');
+                SearchStore.openSearchGenie("search");
             }
         }
 
-        if (((isMac && event.metaKey) || (!isMac && event.ctrlKey)) && event.key === 'm') {
+        if (
+            ((isMac && event.metaKey) || (!isMac && event.ctrlKey)) &&
+            event.key === "m"
+        ) {
             event.preventDefault();
             NavigationStore.toggleSidebar();
         }
-
     };
 
-    window.addEventListener('keydown', globalListener);
+    window.addEventListener("keydown", globalListener);
 
     onBeforeUnmount(() => {
-        window.removeEventListener('keydown', globalListener);
+        window.removeEventListener("keydown", globalListener);
     });
 });
 </script>
 <template>
     <div class="nav-sticky">
         <div class="nav-sticky-info">
-            <div>JER {{ time.toLocaleTimeString('en-US', { hour12: false }) }} (UTC +2)</div>
+            <div>
+                JER
+                {{
+                    new Date(time).toLocaleTimeString("en-US", {
+                        timeZone: "Asia/Jerusalem",
+                        hour12: false,
+                    })
+                }}
+                (UTC +{{ utcOffsetHours }})
+            </div>
             <Link :href="route('homepage')">PalWeb 2.0 (Watermelon)</Link>
         </div>
         <div class="nav-sticky-buttons">
             <button class="material-symbols-rounded" @click="showThemePicker = true">
                 palette
             </button>
-            <button class="material-symbols-rounded" @click="SearchStore.openSearchGenie('search')">
+            <button
+                class="material-symbols-rounded"
+                @click="SearchStore.openSearchGenie('search')"
+            >
                 search
             </button>
             <button class="material-symbols-rounded" @click.stop="NavigationStore.toggleSidebar">
@@ -92,6 +122,6 @@ onMounted(() => {
 <!--    </x-dropdown>-->
 
     <ModalWrapper v-model="showThemePicker">
-        <ThemePicker/>
+        <ThemePicker />
     </ModalWrapper>
 </template>


### PR DESCRIPTION
- I noticed while using the site that the `JER` clock time was liable to drift quite a lot when a page was left open for some time (at one point I think I saw a 20 minute lag!)
- This is caused by using `setInterval`, which is not guaranteed to run exactly every second as specified
  - [Interesting read here](https://johnresig.com/blog/how-javascript-timers-work/) on the browser/JS internals for more detail
- This PR re-jigs the clock code to instead use `Date.now()` and `requestAnimationFrame` to limit the drift, driving the displayed time completely from the client side
- I also noticed when reading about the Palestinian time zones that there is also Daylight Savings to account for, so the server should now send the current UTC offset (normally either 2 hours or 3 hours) and we use that value to display the accurate offset with the clock
- FYI: The extra changes in the Vue file are from prettier auto-formatting running, the actual code changes are only around the date/time handling