### PR TITLE
feat(term-actions): add link to view the root of a term

### DIFF
--- a/resources/js/components/Actions/TermActions.vue
+++ b/resources/js/components/Actions/TermActions.vue
@@ -23,6 +23,9 @@ const deleteTerm = () => {
         <Link :href="route('terms.show', model.slug)" role="menuitem" tabindex="-1">
             View Term
         </Link>
+        <Link :href="route('roots.show', model.id)" role="menuitem" tabindex="-1">
+            View Root
+        </Link>
 
         <template v-if="UserStore.isAdmin">
             <Link :href="route('terms.edit', model.id)" role="menuitem" tabindex="-1">


### PR DESCRIPTION
- currently the term actions only contains one link to view the term itself
- I would find it useful to be able to jump straight to the root of a term without first navigating to the terms page, so I added a menu item for that :)